### PR TITLE
Proposal: add context to dictionary get/set example

### DIFF
--- a/w11/d1/03-python-collections.md
+++ b/w11/d1/03-python-collections.md
@@ -90,10 +90,13 @@
 - We use _square brackets_ to get and set an item's value:
 
 	```python
+	student['name'] = 'Fred'
 	name = student['name']
 	print(name)
 	> Fred
+	
 	student['name'] = 'Tina'
+	name = student['name']
 	print(name)
 	> Tina
 	```


### PR DESCRIPTION
As written, the get/set example demonstrates getting and setting values in a dictionary in a concise way.

As we were going through the lesson I thought that this example was using a reference type variable to store the dictionary. It turns out that this wasn't the case!

I propose revising the example to be a bit less concise but to include a few more of the steps that are implied by the example. What do you think?